### PR TITLE
Add warning to keystore JSON file.

### DIFF
--- a/src/js/IKeystore.ts
+++ b/src/js/IKeystore.ts
@@ -4,7 +4,8 @@ export interface KeyFile{
     salt: string,
     pass_hash: string,
     keys: KeyFileKey[],
-    version: string
+    version: string,
+    warnings: string[]
 }
 
 export interface KeyFileKey {

--- a/src/js/Keystore.ts
+++ b/src/js/Keystore.ts
@@ -91,7 +91,8 @@ async function makeKeyfile(wallets: AvaHdWallet[], pass:string): Promise<KeyFile
         version: KEYSTORE_VERSION,
         salt: bintools.avaSerialize(salt),
         pass_hash: bintools.avaSerialize(passHash.hash),
-        keys: keys
+        keys: keys,
+        warnings: ["This address listed in this file is for internal wallet use only. DO NOT USE THIS ADDRESS"]
     };
     return file_data;
 }
@@ -100,3 +101,5 @@ export {
     readKeyFile,
     makeKeyfile,
 }
+
+

--- a/src/js/Keystore.ts
+++ b/src/js/Keystore.ts
@@ -101,5 +101,3 @@ export {
     readKeyFile,
     makeKeyfile,
 }
-
-


### PR DESCRIPTION
When exporting a keystore, add a "warning" array of strings which alerts the user that the address in the json file is for internal wallet use only.