### PR TITLE
Add magic prefix to signed messages

### DIFF
--- a/src/components/wallet/advanced/VerifyMessage.vue
+++ b/src/components/wallet/advanced/VerifyMessage.vue
@@ -27,6 +27,7 @@
     import {getPreferredHRP} from "avalanche/dist/utils";
     import {avm} from "@/AVA";
     import {Buffer} from "avalanche";
+    import {digestMessage} from "@/helpers/helper";
 
     @Component
     export default class VerifyMessage extends Vue{
@@ -45,12 +46,7 @@
             }
         }
         verify(){
-            let mBuf = Buffer.from(this.message, 'utf8');
-            let msgSize = Buffer.alloc(4);
-            msgSize.writeUInt32BE(mBuf.length, 0);
-            let msgBuff = Buffer.from(`\x1AAvalanche Signed Message:\n${msgSize}${this.message}`, 'utf8');
-            let digest = createHash('sha256').update(msgBuff).digest();
-
+            let digest = digestMessage(this.message);
             let digestBuff = Buffer.from(digest.toString('hex'), 'hex');
 
             let networkId = ava.getNetworkID();

--- a/src/components/wallet/advanced/VerifyMessage.vue
+++ b/src/components/wallet/advanced/VerifyMessage.vue
@@ -46,7 +46,9 @@
         }
         verify(){
             let mBuf = Buffer.from(this.message, 'utf8');
-            let msgBuff = Buffer.from(`\x1AAvalanche Signed Message:\n${mBuf.length.toString(16)}${this.message}`, 'utf8');
+            let msgSize = Buffer.alloc(4);
+            msgSize.writeUInt32BE(mBuf.length, 0);
+            let msgBuff = Buffer.from(`\x1AAvalanche Signed Message:\n${msgSize}${this.message}`, 'utf8');
             let digest = createHash('sha256').update(msgBuff).digest();
 
             let digestBuff = Buffer.from(digest.toString('hex'), 'hex');

--- a/src/components/wallet/advanced/VerifyMessage.vue
+++ b/src/components/wallet/advanced/VerifyMessage.vue
@@ -45,7 +45,8 @@
             }
         }
         verify(){
-            let msgBuff = Buffer.from(`\x1AAvalanche Signed Message:\n${this.message}`, 'utf8');
+            let mBuf = Buffer.from(this.message, 'utf8');
+            let msgBuff = Buffer.from(`\x1AAvalanche Signed Message:\n${mBuf.length.toString(16)}${this.message}`, 'utf8');
             let digest = createHash('sha256').update(msgBuff).digest();
 
             let digestBuff = Buffer.from(digest.toString('hex'), 'hex');

--- a/src/components/wallet/advanced/VerifyMessage.vue
+++ b/src/components/wallet/advanced/VerifyMessage.vue
@@ -45,7 +45,7 @@
             }
         }
         verify(){
-            let msgBuff = Buffer.from(this.message, "utf8");
+            let msgBuff = Buffer.from(`\x1AAvalanche Signed Message:\n${this.message}`, 'utf8');
             let digest = createHash('sha256').update(msgBuff).digest();
 
             let digestBuff = Buffer.from(digest.toString('hex'), 'hex');
@@ -55,7 +55,7 @@
             let hrp = getPreferredHRP(networkId);
             let keypair = new KeyPair(hrp, 'X');
 
-            let signedBuff = Buffer.from(this.signature, 'hex');
+            let signedBuff = bintools.cb58Decode(this.signature);
 
             let pubKey = keypair.recover(digestBuff, signedBuff);
             let addressBuff = keypair.addressFromPublicKey(pubKey);

--- a/src/helpers/helper.ts
+++ b/src/helpers/helper.ts
@@ -16,6 +16,8 @@ import {BN} from "avalanche/dist";
 import Big from 'big.js';
 
 import {PlatformVMConstants} from "avalanche/dist/apis/platformvm";
+import {Buffer} from "avalanche";
+import createHash from "create-hash";
 
 function getAssetIcon(id:string){
     let url = "/question-solid.svg";
@@ -77,5 +79,12 @@ function calculateStakingReward(amount: BN, duration: number, currentSupply: BN)
     return rewardBN;
 }
 
+function digestMessage(msgStr: string){
+    let mBuf = Buffer.from(msgStr, 'utf8');
+    let msgSize = Buffer.alloc(4);
+        msgSize.writeUInt32BE(mBuf.length, 0);
+    let msgBuf = Buffer.from(`\x1AAvalanche Signed Message:\n${msgSize}${msgStr}`, 'utf8');
+    return createHash('sha256').update(msgBuf).digest();
+}
 
-export {getAssetIcon, keyToKeypair, calculateStakingReward, bnToBig};
+export {getAssetIcon, keyToKeypair, calculateStakingReward, bnToBig, digestMessage};

--- a/src/js/wallets/AvaHdWallet.ts
+++ b/src/js/wallets/AvaHdWallet.ts
@@ -367,7 +367,8 @@ export default class AvaHdWallet extends HdWalletCore implements IAvaHdWallet{
         if(index===null) throw "Address not found.";
 
         let key = this.externalHelper.getKeyForIndex(index) as AVMKeyPair;
-        let msgBuf = Buffer.from(`\x1AAvalanche Signed Message:\n${msgStr}`, 'utf8');
+        let mBuf = Buffer.from(msgStr, 'utf8');
+        let msgBuf = Buffer.from(`\x1AAvalanche Signed Message:\n${mBuf.length.toString(16)}${msgStr}`, 'utf8');
         let digest = createHash('sha256').update(msgBuf).digest();
 
         // Convert to the other Buffer and sign

--- a/src/js/wallets/AvaHdWallet.ts
+++ b/src/js/wallets/AvaHdWallet.ts
@@ -367,9 +367,7 @@ export default class AvaHdWallet extends HdWalletCore implements IAvaHdWallet{
         if(index===null) throw "Address not found.";
 
         let key = this.externalHelper.getKeyForIndex(index) as AVMKeyPair;
-
-
-        let msgBuf = Buffer.from(msgStr, 'utf8');
+        let msgBuf = Buffer.from(`\x1AAvalanche Signed Message:\n${msgStr}`, 'utf8');
         let digest = createHash('sha256').update(msgBuf).digest();
 
         // Convert to the other Buffer and sign
@@ -377,6 +375,6 @@ export default class AvaHdWallet extends HdWalletCore implements IAvaHdWallet{
         let digestBuff = Buffer.from(digestHex, 'hex');
         let signed = key.sign(digestBuff);
 
-        return signed.toString('hex');
+        return bintools.cb58Encode(signed)
     }
 }

--- a/src/js/wallets/AvaHdWallet.ts
+++ b/src/js/wallets/AvaHdWallet.ts
@@ -368,7 +368,9 @@ export default class AvaHdWallet extends HdWalletCore implements IAvaHdWallet{
 
         let key = this.externalHelper.getKeyForIndex(index) as AVMKeyPair;
         let mBuf = Buffer.from(msgStr, 'utf8');
-        let msgBuf = Buffer.from(`\x1AAvalanche Signed Message:\n${mBuf.length.toString(16)}${msgStr}`, 'utf8');
+        let msgSize = Buffer.alloc(4);
+        msgSize.writeUInt32BE(mBuf.length, 0);
+        let msgBuf = Buffer.from(`\x1AAvalanche Signed Message:\n${msgSize}${msgStr}`, 'utf8');
         let digest = createHash('sha256').update(msgBuf).digest();
 
         // Convert to the other Buffer and sign

--- a/src/js/wallets/AvaHdWallet.ts
+++ b/src/js/wallets/AvaHdWallet.ts
@@ -38,6 +38,7 @@ import createHash from "create-hash";
 import {HdWalletCore} from "@/js/wallets/HdWalletCore";
 import {WalletType} from "@/store/types";
 import {StandardTx, StandardUnsignedTx} from "avalanche/dist/common";
+import {digestMessage} from "@/helpers/helper";
 
 
 // HD WALLET
@@ -367,11 +368,7 @@ export default class AvaHdWallet extends HdWalletCore implements IAvaHdWallet{
         if(index===null) throw "Address not found.";
 
         let key = this.externalHelper.getKeyForIndex(index) as AVMKeyPair;
-        let mBuf = Buffer.from(msgStr, 'utf8');
-        let msgSize = Buffer.alloc(4);
-        msgSize.writeUInt32BE(mBuf.length, 0);
-        let msgBuf = Buffer.from(`\x1AAvalanche Signed Message:\n${msgSize}${msgStr}`, 'utf8');
-        let digest = createHash('sha256').update(msgBuf).digest();
+        let digest = digestMessage(msgStr);
 
         // Convert to the other Buffer and sign
         let digestHex = digest.toString('hex');

--- a/src/js/wallets/HdWalletCore.ts
+++ b/src/js/wallets/HdWalletCore.ts
@@ -15,6 +15,7 @@ import {UTXOSet as AVMUTXOSet} from "avalanche/dist/apis/avm/utxos";
 import HDKey from "hdkey";
 import {HdHelper} from "@/js/HdHelper";
 import {UTXOSet as PlatformUTXOSet} from "avalanche/dist/apis/platformvm/utxos";
+import createHash from "create-hash";
 
 // A base class other HD wallets are based on.
 // Mnemonic Wallet and LedgerWallet uses this
@@ -240,7 +241,6 @@ class HdWalletCore{
         }
         return unsignedTx;
     }
-
 
 
 }

--- a/src/js/wallets/LedgerWallet.ts
+++ b/src/js/wallets/LedgerWallet.ts
@@ -462,7 +462,6 @@ class LedgerWallet extends HdWalletCore implements AvaWalletCore {
             store.commit('Ledger/closeModal')
             let signed = sigMap.get(pathStr);
             return bintools.cb58Encode(signed);
-            // return signed.toString('hex');
         }catch (e) {
             store.commit('Ledger/closeModal');
             throw e;

--- a/src/js/wallets/LedgerWallet.ts
+++ b/src/js/wallets/LedgerWallet.ts
@@ -32,6 +32,7 @@ import {Credential, SigIdx, Signature, StandardTx, StandardUnsignedTx} from "ava
 import {getPreferredHRP} from "avalanche/dist/utils";
 import {HdWalletCore} from "@/js/wallets/HdWalletCore";
 import {WalletType} from "@/store/types";
+import {digestMessage} from "@/helpers/helper";
 
 class LedgerWallet extends HdWalletCore implements AvaWalletCore {
     app: AppAvax;
@@ -442,14 +443,12 @@ class LedgerWallet extends HdWalletCore implements AvaWalletCore {
 
         if(index===null) throw "Address not found.";
 
-        // this.app.signHash('')
-
         let pathStr = `0/${index}`;
         const addressPath = bippath.fromString(pathStr, false);
         const accountPath = bippath.fromString(`m/44'/9000'/0'`);
 
-        let msgBuf = Buffer.from(msgStr, 'utf8');
-        let digestBuff = Buffer.from(createHash('sha256').update(msgBuf).digest());
+        let digest = digestMessage(msgStr);
+        let digestBuff = Buffer.from(digest);
         let digestHex = digestBuff.toString('hex');
 
         store.commit('Ledger/openModal',{
@@ -462,7 +461,8 @@ class LedgerWallet extends HdWalletCore implements AvaWalletCore {
             let sigMap = await this.app.signHash(accountPath, [addressPath], digestBuff);
             store.commit('Ledger/closeModal')
             let signed = sigMap.get(pathStr);
-            return signed.toString('hex');
+            return bintools.cb58Encode(signed);
+            // return signed.toString('hex');
         }catch (e) {
             store.commit('Ledger/closeModal');
             throw e;


### PR DESCRIPTION
* Add `\x1AAvalanche Signed Message:\n` prefix to message. 
* Return the signature as cb58.