### PR TITLE
Update README to match Node and npm package.json versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This is the frontend Vue.js application for the Avalanche (AVAX) Wallet.
 ## Prerequisites
 
 -   Yarn (https://classic.yarnpkg.com/en/docs/install/)
--   Recent version of npm (6.13.4)
--   Node v12.14.1
+-   Recent version of npm (7.4.0)
+-   Node v15.6.0
 -   Gecko, Avalanche client in Golang (https://github.com/ava-labs/avalanchego)
 
 ## Installation


### PR DESCRIPTION
Update the README Node version to match what's specified in `package.json`:
https://github.com/ava-labs/avalanche-wallet/blob/ed7a78dd2f3bf6310d1db0eca54caf5f23091921/package.json#L5-L7

Also update the npm version specified in the README to [match the npm/Node release page](https://nodejs.org/en/download/releases/).