### PR TITLE
Fix wrong test badges when using local nodes with correct network id

### DIFF
--- a/src/components/NetworkSettings/NetworkMenu.vue
+++ b/src/components/NetworkSettings/NetworkMenu.vue
@@ -129,7 +129,7 @@ export default class NetworkMenu extends Vue {
         let net = this.activeNetwork
 
         if (!net) return false
-        if (net.networkId !== 1) return true
+        if (+net.networkId !== 1) return true
         return false
     }
 }

--- a/src/components/TestNetBanner.vue
+++ b/src/components/TestNetBanner.vue
@@ -11,7 +11,7 @@ export default {
         isVisible() {
             let network = this.$store.state.Network.selectedNetwork
             if (!network) return false
-            let netId = network.networkId
+            let netId = +network.networkId
 
             if (netId === 1) return false
             return true


### PR DESCRIPTION
This fixes false testnet indicators when using a local node via the 'custom network' option. Looks like the network id is a string when a custom network is added. The code checks for numbers. Therefore I added the number conversions.

Previously the wallet showed these two notices:
![image](https://user-images.githubusercontent.com/32718302/118545543-0642a200-b757-11eb-9e11-466fb4605a92.png)

![image](https://user-images.githubusercontent.com/32718302/118545566-0cd11980-b757-11eb-87e1-4d44d6565ed5.png)


