### PR TITLE
Update glacier API link from dev to production

### DIFF
--- a/src/js/Glacier/Glacier.ts
+++ b/src/js/Glacier/Glacier.ts
@@ -1,6 +1,6 @@
 import { Glacier } from '@avalabs/glacier-sdk'
 
 const api = new Glacier({
-    BASE: 'https://glacier-api-dev.avax.network',
+    BASE: 'https://glacier-api.avax.network',
 })
 export default api


### PR DESCRIPTION
Currently looks like we are using `glacier-api-dev`, this PR updates to prod link.

Tested it myself and it worked:

<img width="1728" alt="Screenshot 2023-12-05 at 19 47 12" src="https://github.com/ava-labs/avalanche-wallet/assets/103824766/682dbaa5-f71d-416e-b47b-11569346876e">

